### PR TITLE
Add Readme + fix deploy action hang with 0 PRs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           credentials_json: "${{ secrets.GCP_DATAFLOW_SERVICE_KEY }}"
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@autodetect-feedstock-folders"
+        uses: "pangeo-forge/deploy-recipe-action@v0.3"
         with:
           select_recipe_by_label: true
           pangeo_forge_runner_config: >

--- a/README
+++ b/README
@@ -1,0 +1,4 @@
+# WIP Reproducible example of 'hanging' pgf recipes with CMIP6 data
+
+In this repo I am working towards creating a minimal reproducible example of 'hanging' pgf recipes - meaning recipes that do not error out, but seemingly idle around for many hours (even days). My hope is that this can help inform a fix for https://github.com/pangeo-forge/pangeo-forge-recipes/issues/710 and ultimately avoid a need for my [CMIP6 zombie job killer](https://github.com/leap-stc/cmip6-leap-feedstock/blob/main/.github/workflows/ash.yaml)(which indiscriminately kills jobs after a certain runtime to avoid cost overrun).
+


### PR DESCRIPTION
This PR adds a readme and importantly will trigger the deploy action from a PR. 

For context, I observed [a failure](https://github.com/jbusecke/pgf_cmip_hanging_mre/actions/runs/8393870091) which I believe was caused by the fact that there were 0 prs on this repo (I raised an [issue](https://github.com/pangeo-forge/deploy-recipe-action/issues/31) on the action repo about this). If my assumption was correct this PR should fix this. 